### PR TITLE
Make jupyterlab extension possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# You can build a ready-made Python virtual environment with jupyterlab
+# and jupyter-widget-stixview, and run jupyterlab in it like this:
+#
+#   VENV=$(pwd)/venv
+#   docker build --build-arg VENV=$VENV -t jupyter-stixview .
+#   CONTAINER=$(docker create jupyter-stixview)
+#   docker cp $CONTAINER:$VENV $VENV
+#   docker rm $CONTAINER
+#   $VENV/bin/jupyter lab
+#
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y curl python3-pip python3-venv
+
+RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
+RUN apt-get install -y --no-install-recommends nodejs
+
+ARG VENV=/tmp/venv
+
+RUN mkdir -p $VENV
+WORKDIR $VENV
+RUN chown 1000:1000 $VENV
+USER 1000:1000
+
+RUN python3.6 -m venv $VENV
+RUN bin/pip install --no-cache-dir jupyterlab
+
+COPY . jupyter_widget_stixview
+
+ENV npm_config_cache=/tmp/.npm
+RUN bin/pip install --no-cache-dir jupyter_widget_stixview
+
+RUN set -ex; \
+    export PATH=$VENV/bin:$PATH; \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build; \
+    jupyter labextension install jupyter_widget_stixview/js --no-build; \
+    jupyter lab build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 jupyter-widget-stixview
-===============================
+=======================
 
 [![PyPI version](https://badge.fury.io/py/jupyter-widget-stixview.svg)](https://badge.fury.io/py/jupyter-widget-stixview)
 
@@ -21,7 +21,7 @@ To install use pip:
 
 To install for jupyterlab
 
-    $ jupyter labextension install jupyter_widget_stixview
+    $ jupyter labextension install jupyter-widget-stixview
 
 For a development installation (requires npm),
 
@@ -41,3 +41,8 @@ To see a change, save your javascript, watch the terminal for an update.
 
 Note on first `jupyter lab --watch`, you may need to touch a file to get Jupyter Lab to open.
 
+Troubleshooting
+---------------
+In case of an error like `jlpm: not found` where a JupyterLab command is
+missing, make sure that the `bin` directory (of a Python virtual environment
+where `jupyterlab` is installed to) is on `PATH`.

--- a/js/package.json
+++ b/js/package.json
@@ -31,12 +31,12 @@
     "css-loader": "^4.3.0",
     "rimraf": "^3.0.2",
     "style-loader": "^1.3.0",
-    "svg-inline-loader": "^0.8.2",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^3",
+    "svg-inline-loader": "^0.8.2",
     "lodash": "^4.17.20",
     "stixview": "^1.3.0",
     "yarn": "^1.22.10"


### PR DESCRIPTION
With these changes you can build a venv which has JupyterLab with the extension installed locally following the instruction in Dockerfile. 

I guess you can directly depend on `@jupyter-widgets/jupyterlab-manager` in `package.json` (as far as I can see it enables rendering of your widget in JupyterLab). 

Also `npm` release is needed either way, because I guess you didn't make one after 9365864b, and these changes are also needed for widget rendering in JupyterLab.

